### PR TITLE
Search Menu Manager + search author, blog, post, and all by tag

### DIFF
--- a/TabloidCLI/Models/Post.cs
+++ b/TabloidCLI/Models/Post.cs
@@ -13,5 +13,9 @@ namespace TabloidCLI.Models
         public List<Tag> Tags { get; set; } = new List<Tag>();
         public Author Author { get; set; }
         public Blog Blog { get; set; }
+        public override string ToString()
+        {
+            return $"Title: {Title}\nUrl: ({Url})\n-----------------------";
+        }
     }
 }

--- a/TabloidCLI/Repositories/TagRepository.cs
+++ b/TabloidCLI/Repositories/TagRepository.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Microsoft.Data.SqlClient;
 using TabloidCLI.Models;
 using TabloidCLI.Repositories;
+using TabloidCLI.UserInterfaceManagers;
 
 namespace TabloidCLI
 {
@@ -93,6 +94,44 @@ namespace TabloidCLI
                     cmd.Parameters.AddWithValue("@Id", id);
 
                     cmd.ExecuteNonQuery();
+                }
+            }
+        }
+
+        public SearchResults<Author> SearchAuthors(string tagName)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"SELECT a.id,
+                                               a.FirstName,
+                                               a.LastName,
+                                               a.Bio
+                                          FROM Author a
+                                               LEFT JOIN AuthorTag at on a.Id = at.AuthorId
+                                               LEFT JOIN Tag t on t.Id = at.TagId
+                                         WHERE t.Name LIKE @name";
+                    cmd.Parameters.AddWithValue("@name", $"%{tagName}%");
+                    SqlDataReader reader = cmd.ExecuteReader();
+
+                    SearchResults<Author> results = new SearchResults<Author>();
+                    while (reader.Read())
+                    {
+                        Author author = new Author()
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                            FirstName = reader.GetString(reader.GetOrdinal("FirstName")),
+                            LastName = reader.GetString(reader.GetOrdinal("LastName")),
+                            Bio = reader.GetString(reader.GetOrdinal("Bio")),
+                        };
+                        results.Add(author);
+                    }
+
+                    reader.Close();
+
+                    return results;
                 }
             }
         }

--- a/TabloidCLI/UserInterfaceManagers/PostDetailManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/PostDetailManager.cs
@@ -17,7 +17,7 @@ namespace TabloidCLI.UserInterfaceManagers
         {
             _parentUI = parentUI;
             _postRepository = new PostRepository(connectionString);
-            _postRepository = new PostRepository(connectionString);
+            _authorRepository = new AuthorRepository(connectionString);
             _tagRepository = new TagRepository(connectionString);
             _postId = postId;
         }

--- a/TabloidCLI/UserInterfaceManagers/SearchManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/SearchManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using TabloidCLI.Models;
+using TabloidCLI.Repositories;
 
 namespace TabloidCLI.UserInterfaceManagers
 {
@@ -7,11 +8,17 @@ namespace TabloidCLI.UserInterfaceManagers
     {
         private IUserInterfaceManager _parentUI;
         private TagRepository _tagRepository;
+        private BlogRepository _blogRepository;
+        private PostRepository _postRepository;
+
+
 
         public SearchManager(IUserInterfaceManager parentUI, string connectionString)
         {
             _parentUI = parentUI;
             _tagRepository = new TagRepository(connectionString);
+            _blogRepository = new BlogRepository(connectionString);
+            _postRepository = new PostRepository(connectionString);
         }
 
         public IUserInterfaceManager Execute()
@@ -28,13 +35,16 @@ namespace TabloidCLI.UserInterfaceManagers
             switch (choice)
             {
                 case "1":
+                    SearchBlogs();
                     return this;
                 case "2":
-                    // SearchAuthors();
+                    SearchAuthors();
                     return this;
                 case "3":
+                    SearchPosts();
                     return this;
                 case "4":
+                    SearchAll();
                     return this;
                 case "0":
                     return _parentUI;
@@ -44,21 +54,96 @@ namespace TabloidCLI.UserInterfaceManagers
             }
         }
 
-        //private void SearchAuthors()
-        //{
-        //    Console.Write("Tag> ");
-        //    string tagName = Console.ReadLine();
+        private void SearchAuthors()
+        {
+            Console.Write("Tag> ");
+            string tagName = Console.ReadLine();
 
-        //    SearchResults<Author> results = _tagRepository.SearchAuthors(tagName);
+            SearchResults<Author> results = _tagRepository.SearchAuthors(tagName);
 
-        //    if (results.NoResultsFound)
-        //    {
-        //        Console.WriteLine($"No results for {tagName}");
-        //    }
-        //    else
-        //    {
-        //        results.Display();
-        //    }
-        //}
+            if (results.NoResultsFound)
+            {
+                Console.WriteLine($"No results for {tagName}");
+            }
+            else
+            {
+                results.Display();
+            }
+        }
+
+        private void SearchBlogs()
+        {
+            Console.Write("Tag> ");
+            string tagName = Console.ReadLine();
+
+            SearchResults<Blog> results = _blogRepository.SearchBlogs(tagName);
+
+            if (results.NoResultsFound)
+            {
+                Console.WriteLine($"No results for {tagName}");
+            }
+            else
+            {
+                results.Display();
+            }
+        }
+        private void SearchPosts()
+        {
+            Console.Write("Tag> ");
+            string tagName = Console.ReadLine();
+
+            SearchResults<Post> results = _postRepository.SearchPosts(tagName);
+
+            if (results.NoResultsFound)
+            {
+                Console.WriteLine($"No results for {tagName}");
+            }
+            else
+            {
+                results.Display();
+            }
+        }
+        private void SearchAll()
+        {
+            Console.Write("Tag> ");
+            string tagName = Console.ReadLine();
+            Console.WriteLine($"Search Results: \n");
+
+            SearchResults<Blog> blogResults = _blogRepository.SearchBlogs(tagName);
+            Console.WriteLine("Blogs:");
+
+            if (blogResults.NoResultsFound)
+            {
+                Console.WriteLine($"No results for {tagName}");
+            }
+            else
+            {
+                blogResults.DisplayAll();
+            }
+
+            SearchResults<Author> authorResults = _tagRepository.SearchAuthors(tagName);
+            Console.WriteLine("Authors:");
+
+            if (authorResults.NoResultsFound)
+            {
+                Console.WriteLine($"No results for {tagName}");
+            }
+            else
+            {
+                authorResults.DisplayAll();
+            }
+
+            SearchResults<Post> postResults = _postRepository.SearchPosts(tagName);
+            Console.WriteLine("Posts:");
+
+            if (postResults.NoResultsFound)
+            {
+                Console.WriteLine($"No results for {tagName}");
+            }
+            else
+            {
+                postResults.DisplayAll();
+            }
+        }
     }
 }

--- a/TabloidCLI/UserInterfaceManagers/SearchResults.cs
+++ b/TabloidCLI/UserInterfaceManagers/SearchResults.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using TabloidCLI.Models;
+
 
 namespace TabloidCLI.UserInterfaceManagers
 {
@@ -26,6 +28,16 @@ namespace TabloidCLI.UserInterfaceManagers
         {
             Console.WriteLine(Title);
 
+            foreach (T result in _results)
+            {
+                Console.WriteLine(" " + result);
+            }
+
+            Console.WriteLine();
+        }
+
+        public void DisplayAll()
+        {
             foreach (T result in _results)
             {
                 Console.WriteLine(" " + result);


### PR DESCRIPTION
### Changes
- Search manager was already created with options to search based on Blog, Author, Post, and All
- Built out search functions in SearchManager based on the code provided to search for Author: SearchAuthors(), SearchBlogs(), SearchPosts(), and SearchAll()
- Added ToString override to PostRepository to display post results in search view

### Test
- Open up Search Menu and verify there are options for Search Authors, Search Blogs, Search Posts, and Search All
- When an option is clicked, type in a known tag associated with each entry group (Blog, Author, Post, etc.)
- Verify that if that entry has an associated tag it displays when searched
- Verify that if an entry does NOT have an associated tag it displays "No results for (Tag Name)"

