### PR TITLE
now able to view authors blog posts

### DIFF
--- a/TabloidCLI/Models/Post.cs
+++ b/TabloidCLI/Models/Post.cs
@@ -13,5 +13,9 @@ namespace TabloidCLI.Models
         public List<Tag> Tags { get; set; } = new List<Tag>();
         public Author Author { get; set; }
         public Blog Blog { get; set; }
+        public override string ToString()
+        {
+            return $"Title: {Title}\nBlog: {Blog.Title}\n-----------------------";
+        }
     }
 }


### PR DESCRIPTION
### What I did:
- Added a ToString() method to Post.cs, so you can see the blog and title 

### How to test Author:
- Select 3) Author Management
- Then Select 2) Author Details
- Then Select the one with the Felienne Hermans author, which should be option 3
- Then Select option 2) View Blog Posts, and you should see the title and the blog

### How to test Blog:

- Select 2) Blog Management
- Then Select 2) Blog Details
- Then Select the one with the felienne.com blog, which should be option 3
- Then Select option 2) View Blog Posts, and you should see the title and the blog

Thank you for reviewing!! 