### PR TITLE
Formatting Fixes

### DIFF
--- a/TabloidCLI/UserInterfaceManagers/SearchResults.cs
+++ b/TabloidCLI/UserInterfaceManagers/SearchResults.cs
@@ -30,7 +30,7 @@ namespace TabloidCLI.UserInterfaceManagers
 
             foreach (T result in _results)
             {
-                Console.WriteLine(" " + result);
+                Console.WriteLine(result);
             }
 
             Console.WriteLine();
@@ -40,7 +40,7 @@ namespace TabloidCLI.UserInterfaceManagers
         {
             foreach (T result in _results)
             {
-                Console.WriteLine(" " + result);
+                Console.WriteLine(result);
             }
 
             Console.WriteLine();


### PR DESCRIPTION
### Change
- took away an extra space on Search Results to clean up the view

### Test
- Look at search results and see that there is no extra space in results when displayed